### PR TITLE
Ordering queues by specified order

### DIFF
--- a/ui/php/pat.php
+++ b/ui/php/pat.php
@@ -1,6 +1,6 @@
 <?php
 include('connection.php');   
-$pat = "Select DISTINCT bucode, srf_number, queue_type, t1.queue_name, t2.count, convert_tz(time_added_to_queue , '+00:00','+05:30') as time_added_to_queue from patient t1 inner join( SELECT queue_name, count(*) as count, min(time_added_to_queue) as earliest FROM patient Where queue_type != UPPER('NONE') and queue_name != UPPER('NONE') and queue_name != '0' group by queue_name ) t2 on t1.time_added_to_queue = t2.earliest and t1.queue_name = t2.queue_name order by t1.queue_name";
+$pat = "Select DISTINCT bucode, srf_number, queue_type, t1.queue_name, t2.count, convert_tz(time_added_to_queue , '+00:00','+05:30') as time_added_to_queue from patient t1 inner join( SELECT queue_name, count(*) as count, min(time_added_to_queue) as earliest FROM patient Where queue_type != UPPER('NONE') and queue_name != UPPER('NONE') and queue_name != '0' group by queue_name ) t2 on t1.time_added_to_queue = t2.earliest and t1.queue_name = t2.queue_name order by FIELD(t1.queue_name,'EAST','WEST','SOUTH','BOMMANAHALLI','MAHADEVAPURA','Yelahanka','RAJARAJESWARI NAGAR','DASARAHALLI','Anekal','Bangalore (North)','Bangalore-East','Bangalore-South','OTHER DISTRICT')";
 $stmt = $mysqli->prepare($pat);		
 $stmt->execute();		
 $result = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);		


### PR DESCRIPTION
Ordering queues by specified order 'EAST','WEST','SOUTH','BOMMANAHALLI','MAHADEVAPURA','Yelahanka','RAJARAJESWARI NAGAR','DASARAHALLI','Anekal','Bangalore (North)','Bangalore-East','Bangalore-South','OTHER DISTRICT'

As per email request from Randeep dated Jun 13, 2021, 12:31 AM subject:	Re: Integration of Queuing Public Portal with BBMP Covid Home Page